### PR TITLE
Allow to use custom non aws servers in S3

### DIFF
--- a/src/Foundatio.AWS/Storage/S3FileStorage.cs
+++ b/src/Foundatio.AWS/Storage/S3FileStorage.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using Amazon;
 using Amazon.Runtime;
 using Amazon.S3;
 using Amazon.S3.Model;
@@ -39,7 +40,9 @@ namespace Foundatio.Storage {
                 _client = new AmazonS3Client(
                     credentials,
                     new AmazonS3Config {
-                        ServiceURL = options.ServiceUrl
+                        RegionEndpoint = RegionEndpoint.USEast1,
+                        ServiceURL = options.ServiceUrl,
+                        ForcePathStyle = true
                     });
             }
         }

--- a/src/Foundatio.AWS/Storage/S3FileStorage.cs
+++ b/src/Foundatio.AWS/Storage/S3FileStorage.cs
@@ -19,6 +19,7 @@ namespace Foundatio.Storage {
         private readonly ISerializer _serializer;
         private readonly AmazonS3Client _client;
         private readonly bool _useChunkEncoding;
+        private readonly S3CannedACL _cannedAcl;
 
         public S3FileStorage(S3FileStorageOptions options) {
             if (options == null)
@@ -27,6 +28,7 @@ namespace Foundatio.Storage {
             _bucket = options.Bucket;
             _serializer = options.Serializer ?? DefaultSerializer.Instance;
             _useChunkEncoding = options.UseChunkEncoding ?? true;
+            _cannedAcl = options.CannedACL;
 
             var credentials = options.Credentials ?? FallbackCredentialsFactory.GetCredentials();
 
@@ -107,6 +109,7 @@ namespace Foundatio.Storage {
                 throw new ArgumentNullException(nameof(stream));
 
             var req = new PutObjectRequest {
+                CannedACL = _cannedAcl,
                 BucketName = _bucket,
                 Key = path.Replace('\\', '/'),
                 AutoResetStreamPosition = false,
@@ -126,6 +129,7 @@ namespace Foundatio.Storage {
                 throw new ArgumentNullException(nameof(newPath));
 
             var req = new CopyObjectRequest {
+                CannedACL = _cannedAcl,
                 SourceBucket = _bucket,
                 SourceKey = path.Replace('\\', '/'),
                 DestinationBucket = _bucket,
@@ -152,6 +156,7 @@ namespace Foundatio.Storage {
                 throw new ArgumentNullException(nameof(targetPath));
 
             var req = new CopyObjectRequest {
+                CannedACL = _cannedAcl,
                 SourceBucket = _bucket,
                 SourceKey = path.Replace('\\', '/'),
                 DestinationBucket = _bucket,

--- a/src/Foundatio.AWS/Storage/S3FileStorageConnectionStringBuilder.cs
+++ b/src/Foundatio.AWS/Storage/S3FileStorageConnectionStringBuilder.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using Amazon.S3;
 
 namespace Foundatio.Storage {
     public class S3FileStorageConnectionStringBuilder : AmazonConnectionStringBuilder {
         private string _bucket;
         private string _serviceUrl;
-        private bool? _useChunkEncoding;
+        private string _useChunkEncoding;
+        private string _cannedAcl;
 
         public S3FileStorageConnectionStringBuilder() {
         }
@@ -23,8 +25,13 @@ namespace Foundatio.Storage {
         }
 
         public bool? UseChunkEncoding {
-            get => _useChunkEncoding;
-            set => _useChunkEncoding = value;
+            get => string.IsNullOrEmpty(_useChunkEncoding) ? null : (bool?)Convert.ToBoolean(_useChunkEncoding);
+            set => _useChunkEncoding = value.ToString();
+        }
+
+        public S3CannedACL CannedACL {
+            get => string.IsNullOrEmpty(_cannedAcl) ? null : S3CannedACL.FindValue(_cannedAcl);
+            set => _cannedAcl = value.Value;
         }
 
         protected override bool ParseItem(string key, string value) {
@@ -33,11 +40,16 @@ namespace Foundatio.Storage {
                 return true;
             }
             if (String.Equals(key, "UseChunkEncoding", StringComparison.OrdinalIgnoreCase)) {
-                _useChunkEncoding = Convert.ToBoolean(value);
+                _useChunkEncoding = value;
                 return true;
             }
             if (String.Equals(key, "ServiceUrl", StringComparison.OrdinalIgnoreCase)) {
                 _serviceUrl = value;
+                return true;
+            }
+            if (String.Equals(key, "CannedACL", StringComparison.OrdinalIgnoreCase) ||
+                String.Equals(key, "S3CannedACL", StringComparison.OrdinalIgnoreCase)) {
+                _cannedAcl = value;
                 return true;
             }
 
@@ -48,10 +60,12 @@ namespace Foundatio.Storage {
             var connectionString = base.ToString();
             if (!string.IsNullOrEmpty(_bucket))
                 connectionString += "Bucket=" + Bucket + ";";
-            if (_useChunkEncoding != null)
-                connectionString += "UseChunkEncoding=" + _useChunkEncoding.Value + ";";
+            if (!string.IsNullOrEmpty(_useChunkEncoding))
+                connectionString += "UseChunkEncoding=" + UseChunkEncoding + ";";
             if (!string.IsNullOrEmpty(_serviceUrl))
                 connectionString += "ServiceUrl=" + ServiceUrl + ";";
+            if (!string.IsNullOrEmpty(_cannedAcl))
+                connectionString += "CannedACL=" + CannedACL + ";";
 
             return connectionString;
         }

--- a/src/Foundatio.AWS/Storage/S3FileStorageConnectionStringBuilder.cs
+++ b/src/Foundatio.AWS/Storage/S3FileStorageConnectionStringBuilder.cs
@@ -3,6 +3,8 @@
 namespace Foundatio.Storage {
     public class S3FileStorageConnectionStringBuilder : AmazonConnectionStringBuilder {
         private string _bucket;
+        private string _serviceUrl;
+        private bool? _useChunkEncoding;
 
         public S3FileStorageConnectionStringBuilder() {
         }
@@ -15,11 +17,30 @@ namespace Foundatio.Storage {
             set => _bucket = value;
         }
 
+        public string ServiceUrl {
+            get => _serviceUrl;
+            set => _serviceUrl = value;
+        }
+
+        public bool? UseChunkEncoding {
+            get => _useChunkEncoding;
+            set => _useChunkEncoding = value;
+        }
+
         protected override bool ParseItem(string key, string value) {
             if (String.Equals(key, "Bucket", StringComparison.OrdinalIgnoreCase)) {
                 Bucket = value;
                 return true;
             }
+            if (String.Equals(key, "UseChunkEncoding", StringComparison.OrdinalIgnoreCase)) {
+                _useChunkEncoding = Convert.ToBoolean(value);
+                return true;
+            }
+            if (String.Equals(key, "ServiceUrl", StringComparison.OrdinalIgnoreCase)) {
+                _serviceUrl = value;
+                return true;
+            }
+
             return base.ParseItem(key, value);
         }
 
@@ -27,6 +48,11 @@ namespace Foundatio.Storage {
             var connectionString = base.ToString();
             if (!string.IsNullOrEmpty(_bucket))
                 connectionString += "Bucket=" + Bucket + ";";
+            if (_useChunkEncoding != null)
+                connectionString += "UseChunkEncoding=" + _useChunkEncoding.Value + ";";
+            if (!string.IsNullOrEmpty(_serviceUrl))
+                connectionString += "ServiceUrl=" + ServiceUrl + ";";
+
             return connectionString;
         }
     }

--- a/src/Foundatio.AWS/Storage/S3FileStorageOptions.cs
+++ b/src/Foundatio.AWS/Storage/S3FileStorageOptions.cs
@@ -8,6 +8,8 @@ namespace Foundatio.Storage {
         public string Bucket { get; set; }
         public AWSCredentials Credentials { get; set; }
         public RegionEndpoint Region { get; set; }
+        public bool? UseChunkEncoding { get; set; }
+        public string ServiceUrl { get; set; }
     }
 
     public class S3FileStorageOptionsBuilder : SharedOptionsBuilder<S3FileStorageOptions, S3FileStorageOptionsBuilder> {
@@ -56,6 +58,19 @@ namespace Foundatio.Storage {
             return this;
         }
 
+        public S3FileStorageOptionsBuilder UseChunkEncoding(bool useChunkEncoding) {
+            Target.UseChunkEncoding = useChunkEncoding;
+            return this;
+        }
+
+        public S3FileStorageOptionsBuilder ServiceUrl(string serviceUrl) {
+            if (string.IsNullOrEmpty(serviceUrl))
+                throw new ArgumentNullException(nameof(serviceUrl));
+            Target.ServiceUrl = serviceUrl;
+            return this;
+        }
+
+
         public override S3FileStorageOptions Build() {
             if (String.IsNullOrEmpty(Target.ConnectionString))
                 return Target;
@@ -69,6 +84,12 @@ namespace Foundatio.Storage {
 
             if (String.IsNullOrEmpty(Target.Bucket) && !String.IsNullOrEmpty(connectionString.Bucket))
                 Target.Bucket = connectionString.Bucket;
+
+            if (Target.UseChunkEncoding == null &&  connectionString.UseChunkEncoding != null)
+                Target.UseChunkEncoding = connectionString.UseChunkEncoding;
+
+            if (String.IsNullOrEmpty(Target.ServiceUrl) && !String.IsNullOrEmpty(connectionString.ServiceUrl))
+                Target.ServiceUrl = connectionString.ServiceUrl;
 
             return Target;
         }

--- a/src/Foundatio.AWS/Storage/S3FileStorageOptions.cs
+++ b/src/Foundatio.AWS/Storage/S3FileStorageOptions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Amazon;
 using Amazon.Runtime;
+using Amazon.S3;
 
 namespace Foundatio.Storage {
     public class S3FileStorageOptions : SharedOptions {
@@ -10,6 +11,7 @@ namespace Foundatio.Storage {
         public RegionEndpoint Region { get; set; }
         public bool? UseChunkEncoding { get; set; }
         public string ServiceUrl { get; set; }
+        public S3CannedACL CannedACL { get; set; }
     }
 
     public class S3FileStorageOptionsBuilder : SharedOptionsBuilder<S3FileStorageOptions, S3FileStorageOptionsBuilder> {
@@ -70,6 +72,19 @@ namespace Foundatio.Storage {
             return this;
         }
 
+        public S3FileStorageOptionsBuilder CannedACL(S3CannedACL cannedAcl) {
+            if (cannedAcl == null)
+                throw new ArgumentNullException(nameof(cannedAcl));
+            Target.CannedACL = cannedAcl;
+            return this;
+        }
+
+        public S3FileStorageOptionsBuilder CannedACL(string cannedAcl) {
+            if (string.IsNullOrEmpty(cannedAcl))
+                throw new ArgumentNullException(nameof(cannedAcl));
+            Target.CannedACL = S3CannedACL.FindValue(cannedAcl);
+            return this;
+        }
 
         public override S3FileStorageOptions Build() {
             if (String.IsNullOrEmpty(Target.ConnectionString))
@@ -85,11 +100,14 @@ namespace Foundatio.Storage {
             if (String.IsNullOrEmpty(Target.Bucket) && !String.IsNullOrEmpty(connectionString.Bucket))
                 Target.Bucket = connectionString.Bucket;
 
-            if (Target.UseChunkEncoding == null &&  connectionString.UseChunkEncoding != null)
+            if (Target.UseChunkEncoding == null && connectionString.UseChunkEncoding != null)
                 Target.UseChunkEncoding = connectionString.UseChunkEncoding;
 
             if (String.IsNullOrEmpty(Target.ServiceUrl) && !String.IsNullOrEmpty(connectionString.ServiceUrl))
                 Target.ServiceUrl = connectionString.ServiceUrl;
+
+            if (Target.CannedACL == null && connectionString.CannedACL != null)
+                Target.CannedACL = connectionString.CannedACL;
 
             return Target;
         }


### PR DESCRIPTION
S3 is most popular protocol for cloud storage with a lot of implementations (Ceph, DigitalOcean Spaces, minio etc) official client supports this feature by using ServiceUrl option, but some implementations do not support chunk encoding.
I am add 3 new options
ServiceUrl
UseChunkEncoding (default - true)
and [CannedACL ](https://docs.aws.amazon.com/en_us/AmazonS3/latest/dev/acl-overview.html) for manage access to objects