### PR TITLE
Enable KMS and SQS managed server side encryption for SQS queues

### DIFF
--- a/src/Foundatio.AWS/Foundatio.AWS.csproj
+++ b/src/Foundatio.AWS/Foundatio.AWS.csproj
@@ -6,7 +6,7 @@
   <ItemGroup>
     <PackageReference Include="AWSSDK.CloudWatch" Version="3.7.2.25" />
     <PackageReference Include="AWSSDK.S3" Version="3.7.3.2" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.1.12" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.2.2" />
     <PackageReference Include="Foundatio" Version="10.2.2" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio\Foundatio.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>

--- a/src/Foundatio.AWS/Queues/SQSQueueOptions.cs
+++ b/src/Foundatio.AWS/Queues/SQSQueueOptions.cs
@@ -100,13 +100,13 @@ namespace Foundatio.Queues {
                 throw new ArgumentNullException(nameof(kmsMasterKeyId));
             Target.KmsMasterKeyId = kmsMasterKeyId;
             Target.KmsDataKeyReusePeriodSeconds = kmsKeyReusePeriodSeconds; // Default kms key reuse period is 300 seconds
-            Target.SqsManagedSseEnabled = false; // Must set Sqs Managed SSE to false, as it is one or the other
+            Target.SqsManagedSseEnabled = false; // Must set Sqs Managed SSE to false, as it is either KMS or Sqs Managed - can't have both
             return this;
         }
 
         public SQSQueueOptionsBuilder<T> UseSqsManagedEncryption() {
             Target.SqsManagedSseEnabled = true;
-            Target.KmsMasterKeyId = null; // Must set Sqs Managed SSE to false, as it is one or the other
+            Target.KmsMasterKeyId = null; // Must set KmsMasterKeyId to null, as it is either KMS or Sqs Managed - can't have both
             return this;
         }
 

--- a/src/Foundatio.AWS/Queues/SQSQueueOptions.cs
+++ b/src/Foundatio.AWS/Queues/SQSQueueOptions.cs
@@ -12,7 +12,11 @@ namespace Foundatio.Queues {
         public bool SupportDeadLetter { get; set; } = true;
         public TimeSpan ReadQueueTimeout { get; set; } = TimeSpan.FromSeconds(20);
         public TimeSpan DequeueInterval { get; set; } = TimeSpan.FromSeconds(1);
-        
+        public string KmsMasterKeyId { get; set; }
+        public int KmsDataKeyReusePeriodSeconds { get; set; }
+        public bool SqsManagedSseEnabled { get; set; } = false;
+
+
         private static readonly Random _random = new Random();
         public Func<int, TimeSpan> RetryDelay { get; set; } = attempt => {
             return TimeSpan.FromSeconds(Math.Pow(2, attempt)) + TimeSpan.FromMilliseconds(_random.Next(0, 100));
@@ -88,6 +92,21 @@ namespace Foundatio.Queues {
             if (String.IsNullOrEmpty(region))
                 throw new ArgumentNullException(nameof(region));
             Target.Region = RegionEndpoint.GetBySystemName(region);
+            return this;
+        }
+
+        public SQSQueueOptionsBuilder<T> UseKmsEncryption(string kmsMasterKeyId, int kmsKeyReusePeriodSeconds = 300) {
+            if (String.IsNullOrEmpty(kmsMasterKeyId))
+                throw new ArgumentNullException(nameof(kmsMasterKeyId));
+            Target.KmsMasterKeyId = kmsMasterKeyId;
+            Target.KmsDataKeyReusePeriodSeconds = kmsKeyReusePeriodSeconds; // Default kms key reuse period is 300 seconds
+            Target.SqsManagedSseEnabled = false; // Must set Sqs Managed SSE to false, as it is one or the other
+            return this;
+        }
+
+        public SQSQueueOptionsBuilder<T> UseSqsManagedEncryption() {
+            Target.SqsManagedSseEnabled = true;
+            Target.KmsMasterKeyId = null; // Must set Sqs Managed SSE to false, as it is one or the other
             return this;
         }
 


### PR DESCRIPTION
Open state for enabling server side encryption of SQS queues using either KMS or an SQS managed key.

Related documentation:
https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html
https://docs.aws.amazon.com/sdkfornet/v3/apidocs/items/SQS/TQueueAttributeName.html
https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_CreateQueue.html

Unit tests currently aren't possible because localstack doesn't support setting these specific queue attributes

