### PR TITLE
Respects delivery delay option on send

### DIFF
--- a/src/Foundatio.AWS/Queues/SQSQueue.cs
+++ b/src/Foundatio.AWS/Queues/SQSQueue.cs
@@ -99,8 +99,7 @@ public class SQSQueue<T> : QueueBase<T, SQSQueueOptions<T>> where T : class
         if (options.DeliveryDelay.HasValue)
         {
             int delaySeconds = (int)options.DeliveryDelay.Value.TotalSeconds;
-            if (delaySeconds < 0)
-                delaySeconds = 0;
+            delaySeconds = Math.Max(0, Math.Min(900, delaySeconds)); // Clamp to range [0, 900]
 
             message.DelaySeconds = delaySeconds;
         }

--- a/src/Foundatio.AWS/Queues/SQSQueue.cs
+++ b/src/Foundatio.AWS/Queues/SQSQueue.cs
@@ -99,9 +99,7 @@ public class SQSQueue<T> : QueueBase<T, SQSQueueOptions<T>> where T : class
         if (options.DeliveryDelay.HasValue)
         {
             int delaySeconds = (int)options.DeliveryDelay.Value.TotalSeconds;
-            delaySeconds = Math.Max(0, Math.Min(900, delaySeconds)); // Clamp to range [0, 900]
-
-            message.DelaySeconds = delaySeconds;
+            message.DelaySeconds = Math.Max(0, Math.Min(900, delaySeconds));
         }
 
         if (!String.IsNullOrEmpty(options.UniqueId))

--- a/src/Foundatio.AWS/Queues/SQSQueue.cs
+++ b/src/Foundatio.AWS/Queues/SQSQueue.cs
@@ -99,7 +99,7 @@ public class SQSQueue<T> : QueueBase<T, SQSQueueOptions<T>> where T : class
         if (options.DeliveryDelay.HasValue)
         {
             int delaySeconds = (int)options.DeliveryDelay.Value.TotalSeconds;
-            message.DelaySeconds = Math.Clamp(delaySeconds, 0, 900);
+            message.DelaySeconds = Math.Max(0, Math.Min(900, delaySeconds));
         }
 
         if (!String.IsNullOrEmpty(options.UniqueId))

--- a/src/Foundatio.AWS/Queues/SQSQueue.cs
+++ b/src/Foundatio.AWS/Queues/SQSQueue.cs
@@ -99,7 +99,7 @@ public class SQSQueue<T> : QueueBase<T, SQSQueueOptions<T>> where T : class
         if (options.DeliveryDelay.HasValue)
         {
             int delaySeconds = (int)options.DeliveryDelay.Value.TotalSeconds;
-            message.DelaySeconds = Math.Max(0, Math.Min(900, delaySeconds));
+            message.DelaySeconds = Math.Clamp(delaySeconds, 0, 900);
         }
 
         if (!String.IsNullOrEmpty(options.UniqueId))


### PR DESCRIPTION
Ensures that the `DeliveryDelay` option, when specified on the message itself, is respected by overriding any delay configured on the SQS queue.