### PR TITLE
fix: adapt SQS MessageBus to two-phase dispose lifecycle

### DIFF
--- a/src/Foundatio.AWS/Foundatio.AWS.csproj
+++ b/src/Foundatio.AWS/Foundatio.AWS.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="AWSSDK.SimpleNotificationService" Version="4.0.2.27" />
     <PackageReference Include="AWSSDK.SQS" Version="4.0.2.25" />
 
-    <PackageReference Include="Foundatio" Version="13.0.0-beta5" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio" Version="13.0.0-beta5.2" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio\Foundatio.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/src/Foundatio.AWS/Messaging/SQSMessageBus.cs
+++ b/src/Foundatio.AWS/Messaging/SQSMessageBus.cs
@@ -383,7 +383,7 @@ public class SQSMessageBus : MessageBusBase<SQSMessageBusOptions>
         }
     }
 
-    protected override async Task CleanupAsync()
+    protected override async Task RemoveTopicSubscriptionAsync()
     {
         if (_subscriberCts is not null)
         {
@@ -416,7 +416,10 @@ public class SQSMessageBus : MessageBusBase<SQSMessageBusOptions>
                 _logger.LogWarning(ex, "Error waiting for subscriber task to complete during dispose");
             }
         }
+    }
 
+    protected override async Task CleanupAsync()
+    {
         _subscriberCts?.Dispose();
 
         if (!String.IsNullOrEmpty(_subscriptionArn) && _snsClient.IsValueCreated)

--- a/src/Foundatio.AWS/Messaging/SQSMessageBus.cs
+++ b/src/Foundatio.AWS/Messaging/SQSMessageBus.cs
@@ -388,7 +388,7 @@ public class SQSMessageBus : MessageBusBase<SQSMessageBusOptions>
         if (_subscriberCts is not null)
         {
             try { await _subscriberCts.CancelAsync().AnyContext(); }
-            catch (ObjectDisposedException) { }
+            catch (ObjectDisposedException ex) { _logger.LogTrace(ex, "Subscriber CTS already disposed during cleanup"); }
         }
 
         if (_subscriberTask is not null)
@@ -397,12 +397,12 @@ public class SQSMessageBus : MessageBusBase<SQSMessageBusOptions>
             {
                 await _subscriberTask.WaitAsync(TimeSpan.FromSeconds(5)).AnyContext();
             }
-            catch (OperationCanceledException) { }
+            catch (OperationCanceledException ex) { _logger.LogTrace(ex, "Subscriber task cancelled during cleanup"); }
             catch (TimeoutException)
             {
                 _logger.LogWarning("Subscriber task did not complete within timeout during dispose");
             }
-            catch (AggregateException ex)
+            catch (Exception ex)
             {
                 _logger.LogWarning(ex, "Error waiting for subscriber task to complete during dispose");
             }
@@ -557,7 +557,7 @@ public class SQSMessageBus : MessageBusBase<SQSMessageBusOptions>
     private async Task<bool> ProcessMessageAsync(Amazon.SQS.Model.Message sqsMessage, CancellationToken cancellationToken)
     {
         if (_subscribers.IsEmpty)
-            return false;
+            return !cancellationToken.IsCancellationRequested;
 
         _logger.LogTrace("Processing message {MessageId}", sqsMessage.MessageId);
 

--- a/src/Foundatio.AWS/Messaging/SQSMessageBus.cs
+++ b/src/Foundatio.AWS/Messaging/SQSMessageBus.cs
@@ -61,7 +61,7 @@ namespace Foundatio.Messaging;
 /// </remarks>
 /// <seealso cref="SQSMessageBusOptions"/>
 /// <seealso cref="SQSMessageBusOptionsBuilder"/>
-public class SQSMessageBus : MessageBusBase<SQSMessageBusOptions>, IAsyncDisposable
+public class SQSMessageBus : MessageBusBase<SQSMessageBusOptions>
 {
     private readonly AsyncLock _lock = new();
     private readonly Lazy<AmazonSimpleNotificationServiceClient> _snsClient;
@@ -72,7 +72,6 @@ public class SQSMessageBus : MessageBusBase<SQSMessageBusOptions>, IAsyncDisposa
     private string? _subscriptionArn;
     private CancellationTokenSource? _subscriberCts;
     private Task? _subscriberTask;
-    private bool _isDisposed;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SQSMessageBus"/> class with the specified options.
@@ -384,18 +383,32 @@ public class SQSMessageBus : MessageBusBase<SQSMessageBusOptions>, IAsyncDisposa
         }
     }
 
-    protected override async Task RemoveTopicSubscriptionAsync()
+    protected override async Task CleanupAsync()
     {
         if (_subscriberCts is not null)
         {
+            try { await _subscriberCts.CancelAsync().AnyContext(); }
+            catch (ObjectDisposedException) { }
+        }
+
+        if (_subscriberTask is not null)
+        {
             try
             {
-                await _subscriberCts.CancelAsync().AnyContext();
+                await _subscriberTask.WaitAsync(TimeSpan.FromSeconds(5)).AnyContext();
             }
-            catch (ObjectDisposedException)
+            catch (OperationCanceledException) { }
+            catch (TimeoutException)
             {
+                _logger.LogWarning("Subscriber task did not complete within timeout during dispose");
+            }
+            catch (AggregateException ex)
+            {
+                _logger.LogWarning(ex, "Error waiting for subscriber task to complete during dispose");
             }
         }
+
+        _subscriberCts?.Dispose();
 
         if (!String.IsNullOrEmpty(_subscriptionArn) && _snsClient.IsValueCreated)
         {
@@ -435,6 +448,12 @@ public class SQSMessageBus : MessageBusBase<SQSMessageBusOptions>, IAsyncDisposa
 
         _queueUrl = null;
         _queueArn = null;
+
+        if (_snsClient.IsValueCreated)
+            _snsClient.Value.Dispose();
+
+        if (_sqsClient.IsValueCreated)
+            _sqsClient.Value.Dispose();
     }
 
     private async Task SubscriberLoopAsync(CancellationToken cancellationToken)
@@ -485,13 +504,16 @@ public class SQSMessageBus : MessageBusBase<SQSMessageBusOptions>, IAsyncDisposa
 
                     try
                     {
-                        await ProcessMessageAsync(sqsMessage, cancellationToken).AnyContext();
+                        bool handled = await ProcessMessageAsync(sqsMessage, cancellationToken).AnyContext();
 
-                        await _sqsClient.Value.DeleteMessageAsync(new DeleteMessageRequest
+                        if (handled)
                         {
-                            QueueUrl = _queueUrl,
-                            ReceiptHandle = sqsMessage.ReceiptHandle
-                        }, CancellationToken.None).AnyContext();
+                            await _sqsClient.Value.DeleteMessageAsync(new DeleteMessageRequest
+                            {
+                                QueueUrl = _queueUrl,
+                                ReceiptHandle = sqsMessage.ReceiptHandle
+                            }, CancellationToken.None).AnyContext();
+                        }
                     }
                     catch (ReceiptHandleIsInvalidException ex)
                     {
@@ -532,10 +554,10 @@ public class SQSMessageBus : MessageBusBase<SQSMessageBusOptions>, IAsyncDisposa
         _logger.LogTrace("Subscriber loop ended for {MessageBusId}", MessageBusId);
     }
 
-    private async Task ProcessMessageAsync(Amazon.SQS.Model.Message sqsMessage, CancellationToken cancellationToken)
+    private async Task<bool> ProcessMessageAsync(Amazon.SQS.Model.Message sqsMessage, CancellationToken cancellationToken)
     {
         if (_subscribers.IsEmpty)
-            return;
+            return false;
 
         _logger.LogTrace("Processing message {MessageId}", sqsMessage.MessageId);
 
@@ -577,6 +599,7 @@ public class SQSMessageBus : MessageBusBase<SQSMessageBusOptions>, IAsyncDisposa
             message.Properties[property.Key] = property.Value;
 
         await SendMessageToSubscribersAsync(message).AnyContext();
+        return true;
     }
 
     protected override async Task PublishImplAsync(string messageType, object message, MessageOptions options, CancellationToken cancellationToken)
@@ -658,83 +681,6 @@ public class SQSMessageBus : MessageBusBase<SQSMessageBusOptions>, IAsyncDisposa
                 throw new MessageBusException($"Failed to publish message to SNS topic {topicName}: {ex.Message}", ex);
             }
         }, cancellationToken).AnyContext();
-    }
-
-    /// <summary>
-    /// Asynchronously releases all resources used by the message bus.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// Disposal performs the following cleanup operations:
-    /// <list type="bullet">
-    /// <item>Cancels and waits for the subscriber polling loop to complete</item>
-    /// <item>Unsubscribes the SQS queue from the SNS topic</item>
-    /// <item>Deletes the SQS queue if <see cref="SQSMessageBusOptions.SubscriptionQueueAutoDelete"/> is true</item>
-    /// <item>Disposes the SNS and SQS clients</item>
-    /// </list>
-    /// </para>
-    /// <para>
-    /// For durable subscriptions, set <see cref="SQSMessageBusOptions.SubscriptionQueueAutoDelete"/> to false
-    /// to preserve the queue across restarts.
-    /// </para>
-    /// </remarks>
-    public async ValueTask DisposeAsync()
-    {
-        if (_isDisposed)
-            return;
-
-        _isDisposed = true;
-        BeginDispose();
-        await CleanupAsync().AnyContext();
-    }
-
-    /// <inheritdoc />
-    public override void Dispose()
-    {
-        if (_isDisposed)
-            return;
-
-        _isDisposed = true;
-        BeginDispose();
-        Task.Run(() => CleanupAsync()).GetAwaiter().GetResult();
-    }
-
-    private void BeginDispose()
-    {
-        try { _subscriberCts?.Cancel(); }
-        catch (ObjectDisposedException) { }
-
-        base.Dispose();
-    }
-
-    private async Task CleanupAsync()
-    {
-        if (_subscriberTask is not null)
-        {
-            try
-            {
-                await _subscriberTask.WaitAsync(TimeSpan.FromSeconds(5)).AnyContext();
-            }
-            catch (OperationCanceledException) { }
-            catch (TimeoutException)
-            {
-                _logger.LogWarning("Subscriber task did not complete within timeout during dispose");
-            }
-            catch (AggregateException ex)
-            {
-                _logger.LogWarning(ex, "Error waiting for subscriber task to complete during dispose");
-            }
-        }
-
-        _subscriberCts?.Dispose();
-
-        await RemoveTopicSubscriptionAsync().AnyContext();
-
-        if (_snsClient.IsValueCreated)
-            _snsClient.Value.Dispose();
-
-        if (_sqsClient.IsValueCreated)
-            _sqsClient.Value.Dispose();
     }
 
     /// <summary>

--- a/src/Foundatio.AWS/Messaging/SQSMessageBus.cs
+++ b/src/Foundatio.AWS/Messaging/SQSMessageBus.cs
@@ -387,8 +387,14 @@ public class SQSMessageBus : MessageBusBase<SQSMessageBusOptions>
     {
         if (_subscriberCts is not null)
         {
-            try { await _subscriberCts.CancelAsync().AnyContext(); }
-            catch (ObjectDisposedException ex) { _logger.LogTrace(ex, "Subscriber CTS already disposed during cleanup"); }
+            try
+            {
+                await _subscriberCts.CancelAsync().AnyContext();
+            }
+            catch (ObjectDisposedException ex)
+            {
+                _logger.LogTrace(ex, "Subscriber CTS already disposed during cleanup");
+            }
         }
 
         if (_subscriberTask is not null)
@@ -397,7 +403,10 @@ public class SQSMessageBus : MessageBusBase<SQSMessageBusOptions>
             {
                 await _subscriberTask.WaitAsync(TimeSpan.FromSeconds(5)).AnyContext();
             }
-            catch (OperationCanceledException ex) { _logger.LogTrace(ex, "Subscriber task cancelled during cleanup"); }
+            catch (OperationCanceledException ex)
+            {
+                _logger.LogTrace(ex, "Subscriber task cancelled during cleanup");
+            }
             catch (TimeoutException)
             {
                 _logger.LogWarning("Subscriber task did not complete within timeout during dispose");

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -12,7 +12,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.3" PrivateAssets="All" />
 
-    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta5" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
+    <PackageReference Include="Foundatio.TestHarness" Version="13.0.0-beta5.2" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio.TestHarness\Foundatio.TestHarness.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />
   </ItemGroup>
 </Project>

--- a/tests/Foundatio.AWS.Tests/Messaging/SQSMessageBusTests.cs
+++ b/tests/Foundatio.AWS.Tests/Messaging/SQSMessageBusTests.cs
@@ -205,6 +205,42 @@ public class SQSMessageBusTests : MessageBusTestBase
     }
 
     [Fact]
+    public override Task DisposeAsync_CalledMultipleTimes_IsIdempotentAsync()
+    {
+        return base.DisposeAsync_CalledMultipleTimes_IsIdempotentAsync();
+    }
+
+    [Fact]
+    public override Task DisposeAsync_WhilePublishing_CompletesWithoutDeadlockAsync()
+    {
+        return base.DisposeAsync_WhilePublishing_CompletesWithoutDeadlockAsync();
+    }
+
+    [Fact]
+    public override Task DisposeAsync_WithNoSubscribersOrPublishers_CompletesWithoutExceptionAsync()
+    {
+        return base.DisposeAsync_WithNoSubscribersOrPublishers_CompletesWithoutExceptionAsync();
+    }
+
+    [Fact]
+    public override Task PublishAsync_AfterDispose_ThrowsMessageBusExceptionAsync()
+    {
+        return base.PublishAsync_AfterDispose_ThrowsMessageBusExceptionAsync();
+    }
+
+    [Fact]
+    public override Task SubscribeAsync_AfterDispose_ThrowsMessageBusExceptionAsync()
+    {
+        return base.SubscribeAsync_AfterDispose_ThrowsMessageBusExceptionAsync();
+    }
+
+    [Fact]
+    public override Task SubscribeAsync_CancelledToken_DoesNotTearDownInfrastructureAsync()
+    {
+        return base.SubscribeAsync_CancelledToken_DoesNotTearDownInfrastructureAsync();
+    }
+
+    [Fact]
     public override Task CanHandlePoisonedMessageAsync()
     {
         return base.CanHandlePoisonedMessageAsync();

--- a/tests/Foundatio.AWS.Tests/Messaging/SQSMessageBusTests.cs
+++ b/tests/Foundatio.AWS.Tests/Messaging/SQSMessageBusTests.cs
@@ -205,6 +205,12 @@ public class SQSMessageBusTests : MessageBusTestBase
     }
 
     [Fact]
+    public override Task CanHandlePoisonedMessageAsync()
+    {
+        return base.CanHandlePoisonedMessageAsync();
+    }
+
+    [Fact]
     public override Task DisposeAsync_CalledMultipleTimes_IsIdempotentAsync()
     {
         return base.DisposeAsync_CalledMultipleTimes_IsIdempotentAsync();
@@ -229,6 +235,12 @@ public class SQSMessageBusTests : MessageBusTestBase
     }
 
     [Fact]
+    public override Task PublishAsync_WithSerializationFailure_ThrowsSerializerExceptionAsync()
+    {
+        return base.PublishAsync_WithSerializationFailure_ThrowsSerializerExceptionAsync();
+    }
+
+    [Fact]
     public override Task SubscribeAsync_AfterDispose_ThrowsMessageBusExceptionAsync()
     {
         return base.SubscribeAsync_AfterDispose_ThrowsMessageBusExceptionAsync();
@@ -241,27 +253,15 @@ public class SQSMessageBusTests : MessageBusTestBase
     }
 
     [Fact]
-    public override Task CanHandlePoisonedMessageAsync()
+    public override Task SubscribeAsync_WithDeserializationFailure_SkipsMessageAsync()
     {
-        return base.CanHandlePoisonedMessageAsync();
+        return base.SubscribeAsync_WithDeserializationFailure_SkipsMessageAsync();
     }
 
     [Fact]
     public override Task SubscribeAsync_WithValidThenPoisonedMessage_DeliversOnlyValidMessageAsync()
     {
         return base.SubscribeAsync_WithValidThenPoisonedMessage_DeliversOnlyValidMessageAsync();
-    }
-
-    [Fact]
-    public override Task PublishAsync_WithSerializationFailure_ThrowsSerializerExceptionAsync()
-    {
-        return base.PublishAsync_WithSerializationFailure_ThrowsSerializerExceptionAsync();
-    }
-
-    [Fact]
-    public override Task SubscribeAsync_WithDeserializationFailure_SkipsMessageAsync()
-    {
-        return base.SubscribeAsync_WithDeserializationFailure_SkipsMessageAsync();
     }
 
     [Fact] // 2 minute timeout for durable queue test

--- a/tests/Foundatio.AWS.Tests/Messaging/SQSMessageBusTests.cs
+++ b/tests/Foundatio.AWS.Tests/Messaging/SQSMessageBusTests.cs
@@ -199,9 +199,9 @@ public class SQSMessageBusTests : MessageBusTestBase
     }
 
     [Fact]
-    public override void CanDisposeWithNoSubscribersOrPublishers()
+    public override Task CanDisposeWithNoSubscribersOrPublishersAsync()
     {
-        base.CanDisposeWithNoSubscribersOrPublishers();
+        return base.CanDisposeWithNoSubscribersOrPublishersAsync();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Move cleanup into \CleanupAsync\ override consolidating old RemoveTopicSubscriptionAsync/BeginDispose/private CleanupAsync
- Fix \ProcessMessageAsync\ to return \ool\ for conditional message deletion (preserve in-flight messages)
- Remove ad-hoc Dispose/DisposeAsync/BeginDispose and shadowed \_isDisposed\

## Dependencies
- Depends on FoundatioFx/Foundatio#492 (core two-phase dispose)

## Test plan
- [x] Builds with local Foundatio source (\ReferenceFoundatioSource=true\)
- [ ] CI runs integration tests with SQS