### PR TITLE
fix: correct disposal ordering to prevent ObjectDisposedException during shutdown

### DIFF
--- a/src/Foundatio.AWS/Foundatio.AWS.csproj
+++ b/src/Foundatio.AWS/Foundatio.AWS.csproj
@@ -4,10 +4,10 @@
     <PackageTags>$(PackageTags);Amazon;AWS;S3;SNS;SQS</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.CloudWatch" Version="4.0.10.4" />
-    <PackageReference Include="AWSSDK.S3" Version="4.0.23.3" />
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="4.0.2.33" />
-    <PackageReference Include="AWSSDK.SQS" Version="4.0.2.31" />
+    <PackageReference Include="AWSSDK.CloudWatch" Version="4.0.12" />
+    <PackageReference Include="AWSSDK.S3" Version="4.0.24.2" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="4.0.3.2" />
+    <PackageReference Include="AWSSDK.SQS" Version="4.0.3.2" />
 
     <PackageReference Include="Foundatio" Version="13.0.2-preview.0.4" Condition="'$(ReferenceFoundatioSource)' == '' OR '$(ReferenceFoundatioSource)' == 'false'" />
     <ProjectReference Include="..\..\..\Foundatio\src\Foundatio\Foundatio.csproj" Condition="'$(ReferenceFoundatioSource)' == 'true'" />

--- a/src/Foundatio.AWS/Queues/SQSQueue.cs
+++ b/src/Foundatio.AWS/Queues/SQSQueue.cs
@@ -452,13 +452,11 @@ public class SQSQueue<T> : QueueBase<T, SQSQueueOptions<T>> where T : class
 
     public override void Dispose()
     {
-        if (IsDisposed)
+        if (!SignalDispose())
         {
             _logger.LogTrace("Queue {QueueName} ({QueueId}) dispose was already called", _options.Name, QueueId);
             return;
         }
-
-        SignalDispose();
 
         if (_client.IsValueCreated)
             _client.Value.Dispose();

--- a/src/Foundatio.AWS/Queues/SQSQueue.cs
+++ b/src/Foundatio.AWS/Queues/SQSQueue.cs
@@ -452,10 +452,18 @@ public class SQSQueue<T> : QueueBase<T, SQSQueueOptions<T>> where T : class
 
     public override void Dispose()
     {
-        base.Dispose();
+        if (IsDisposed)
+        {
+            _logger.LogTrace("Queue {QueueName} ({QueueId}) dispose was already called", _options.Name, QueueId);
+            return;
+        }
+
+        SignalDispose();
 
         if (_client.IsValueCreated)
             _client.Value.Dispose();
+
+        base.Dispose();
     }
 
     protected virtual async Task CreateQueueAsync()

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -7,7 +7,7 @@
     <NoWarn>$(NoWarn);CS1591;NU1701</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="GitHubActionsTestLogger" Version="3.0.4" PrivateAssets="All" />


### PR DESCRIPTION
## Summary

- Reorder SQSQueue.Dispose() to call SignalDispose() first (cancels the CTS token so background tasks observe shutdown), dispose resources, then call base.Dispose() last (which disposes the timer and CTS)
- Add idempotency guard with diagnostic trace logging on re-entry

This prevents a potential ObjectDisposedException if the CancellationTokenSource is disposed while background tasks are still checking the token -- the same class of bug fixed in FoundatioFx/Foundatio.Redis#165.

## Related

- FoundatioFx/Foundatio.Redis#165
- FoundatioFx/Foundatio#519

## Test plan

- [x] Builds cleanly with dotnet build -p:ReferenceFoundatioSource=true
- [ ] Existing queue tests continue to pass